### PR TITLE
[fix] using distinct keyword

### DIFF
--- a/models/optimism/decoded_optimism_logs.sql
+++ b/models/optimism/decoded_optimism_logs.sql
@@ -64,7 +64,7 @@ logs_with_event_id AS (
 ),
 
 merged AS (
-    SELECT
+    SELECT DISTINCT
         l.*,
         e.event_id,
         e.abi,

--- a/models/optimism/decoded_optimism_traces.sql
+++ b/models/optimism/decoded_optimism_traces.sql
@@ -73,7 +73,7 @@
 {% endif %}
 
 merged AS (
-    SELECT
+    SELECT DISTINCT
         t.*,
         m.METHOD_ID,
         m.hashable_signature,

--- a/models/optimism/decoded_optimism_transactions.sql
+++ b/models/optimism/decoded_optimism_transactions.sql
@@ -113,7 +113,7 @@
 {% endif %}
 
 merged AS (
-    SELECT
+    SELECT DISTINCT
         t.*,
         m.METHOD_ID,
         m.hashable_signature,


### PR DESCRIPTION
There are no duplicates in contracts, method fragments or event fragments table but this will resolve this error we are getting from the DAG

`Duplicate row detected during DML action`