### PR TITLE
[fix]redo traces unique key for BASE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 dbt_packages/
 logs/
 profiles.yml
+.user.yml

--- a/models/base/decoded_testnet_base_traces.sql
+++ b/models/base/decoded_testnet_base_traces.sql
@@ -1,4 +1,4 @@
-{{ config(materialized='incremental', unique_key=['trace_hash'], merge_update_columns = ['hashable_signature', 'decoded_input'], cluster_by=['transaction_hash']) }}
+{{ config(materialized='incremental', unique_key=['transaction_hash','trace_hash','parent_hash','trace_index'], merge_update_columns = ['hashable_signature', 'decoded_input'], cluster_by=['transaction_hash']) }}
 
 {% if is_incremental() %}
     {% if not var('backfill') %} -- if not backfilling


### PR DESCRIPTION
Confirmed in snowflake that traces can have the same trace hash. Additionally they can also have the same parent hash and transaction hash. Therefore, as a pkey, we need to create a composite key that consists of `tx_hash`, `parent_hash`, `trace_hash`, and `trace_index`, similar to the unique key we have for optimism and ETH. 